### PR TITLE
feat: remove switch sites dropdown from navigation header

### DIFF
--- a/src/_includes/home.njk
+++ b/src/_includes/home.njk
@@ -14,7 +14,7 @@ layout: default.njk
     <div class="mds-content-chunk mu-py-xl-09">
       <h1 class="mu-display-heading-1 mu-mb-00">Mosaic<br>Design System</h1>
       <p class="mu-mb-00">{{ home.strap_line }}</p>
-      <a href="https://github.com/mosaic-design" target="_blank" class="mcc-button mcc-button--lg mcc-button--outline  mu-mt-07" type="button">
+      <a href="https://github.com/mosaic-design-system" target="_blank" class="mcc-button mcc-button--lg mcc-button--outline  mu-mt-07" type="button">
         <mcc-icon name="github" icon-set="fluency-filled" aria-hidden="true"></mcc-icon>
         <span class="mcc-button__label">GitHub</span>
       </a>

--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -17,7 +17,6 @@
   <nav class="mcc-navigation-header__global" style="gap: 0.5rem;">
     {% include "../search/search-button.njk" %}
     {% include "../theme-toggle/theme-toggle.njk" %}
-    {% include "../switch-sites/switch-sites.njk" %}
   </nav>
 
 </header>


### PR DESCRIPTION
This PR removes the switch sites dropdown from navigation header. 